### PR TITLE
Improve fuzzy matching for Chinese text

### DIFF
--- a/product_manager.py
+++ b/product_manager.py
@@ -150,7 +150,16 @@ class ProductManager:
             if self.seasonal_products:
                 logger.info(f"当季推荐产品: {len(self.seasonal_products)} 条")
             return True
-    
+
+    def _tokenize(self, text):
+        """Tokenize text into alphanumeric words and Chinese characters/bigrams"""
+        text = text.lower()
+        tokens = re.findall(r'[A-Za-z0-9]+', text)
+        for seq in re.findall(r'[\u4e00-\u9fff]+', text):
+            tokens.extend(list(seq))
+            tokens.extend([seq[i:i+2] for i in range(len(seq)-1)])
+        return tokens
+
     def _extract_all_keywords(self):
         """从产品目录中提取所有关键词
         
@@ -166,14 +175,15 @@ class ProductManager:
                 keywords.append(product_name)
                 
             # 添加单个词作为关键词
-            for word in re.findall(r'[\w\u4e00-\u9fff]+', product_name):
+            for word in self._tokenize(product_name):
                 if len(word) > 1 and word not in keywords:
                     keywords.append(word)
 
             # 添加自定义关键词
             for kw in details.get('keywords', []):
-                if kw and kw not in keywords:
-                    keywords.append(kw)
+                for tok in self._tokenize(kw):
+                    if tok and tok not in keywords:
+                        keywords.append(tok)
                     
         return keywords
     
@@ -287,14 +297,16 @@ class ProductManager:
             return direct_matches
 
         # 2. 尝试关键词部分匹配 (Jaccard相似度)
-        query_words = set(re.findall(r'[\w\u4e00-\u9fff]+', query_lower))
+        query_words = set(self._tokenize(query_lower))
         if not query_words:
             return []
 
         for key, details in self.product_catalog.items():
-            product_name_words = set(re.findall(r'[\w\u4e00-\u9fff]+', details['name'].lower()))
-            product_key_words = set(re.findall(r'[\w\u4e00-\u9fff]+', key))
-            keywords_words = set(details.get('keywords', []))
+            product_name_words = set(self._tokenize(details['name'].lower()))
+            product_key_words = set(self._tokenize(key))
+            keywords_words = set()
+            for kw in details.get('keywords', []):
+                keywords_words.update(self._tokenize(kw))
 
             # 名称和key的Jaccard相似度
             intersection_name = query_words.intersection(product_name_words)

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -21,5 +21,16 @@ class TestChineseNumberConversion(unittest.TestCase):
     def test_unknown(self):
         self.assertEqual(self.pm.convert_chinese_number_to_int('百'), 1)
 
+
+class TestFuzzyMatch(unittest.TestCase):
+    def setUp(self):
+        self.pm = ProductManager()
+        self.pm.load_product_data()
+
+    def test_match_mother_chicken(self):
+        results = self.pm.fuzzy_match_product('母鸡多少钱', threshold=0.05)
+        self.assertTrue(results, 'No products matched the query')
+        self.assertEqual(results[0][0], '农场素食散养走地萨松母鸡')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `_tokenize` helper in `product_manager` for mixed English/Chinese tokenization
- reuse `_tokenize` inside keyword extraction and fuzzy matching
- expand tests to cover fuzzy match on Chinese query

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb75621848326a0609d7223303ee9