### PR TITLE
Add policy manager and policy Q&A

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ env/
 # Operating System files
 .DS_Store
 Thumbs.db
+cache/

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ import config # 新增：导入配置文件
 from cache_manager import CacheManager
 from product_manager import ProductManager
 from chat_handler import ChatHandler
+from policy_manager import PolicyManager
 
 app = Flask(__name__)
 
@@ -25,13 +26,16 @@ logger.info(" Flask app object created. ") # 修改
 # --- 初始化管理器 ---
 cache_manager = CacheManager()
 product_manager = ProductManager(cache_manager=cache_manager)
+policy_manager = PolicyManager()
 # 加载产品数据 (product_manager 内部会处理缓存)
 if not product_manager.load_product_data():
     logger.error("应用启动失败：无法加载产品数据。请检查 products.csv 文件和配置。")
     # 在这种情况下，应用可能无法正常工作，可以考虑退出或进入维护模式
     # exit(1) # 或者其他错误处理机制
 
-chat_handler = ChatHandler(product_manager=product_manager, cache_manager=cache_manager)
+chat_handler = ChatHandler(product_manager=product_manager,
+                           policy_manager=policy_manager,
+                           cache_manager=cache_manager)
 
 @app.route('/')
 def index():

--- a/chat_handler.py
+++ b/chat_handler.py
@@ -4,6 +4,7 @@ import config
 from typing import Tuple, Optional, Dict, Any
 from cache_manager import CacheManager
 from product_manager import ProductManager
+from policy_manager import PolicyManager
 import random
 
 # 配置日志
@@ -12,7 +13,9 @@ logger = logging.getLogger(__name__)
 class ChatHandler:
     """聊天处理类，负责处理用户输入和意图识别"""
     
-    def __init__(self, product_manager: ProductManager, cache_manager: CacheManager = None):
+    def __init__(self, product_manager: ProductManager,
+                 policy_manager: PolicyManager = None,
+                 cache_manager: CacheManager = None):
         """初始化聊天处理器
         
         Args:
@@ -20,6 +23,7 @@ class ChatHandler:
             cache_manager (CacheManager, optional): 缓存管理器实例
         """
         self.product_manager = product_manager
+        self.policy_manager = policy_manager or PolicyManager()
         self.cache_manager = cache_manager or CacheManager()
         
         # 用户会话状态
@@ -136,8 +140,8 @@ class ChatHandler:
             user_input_processed (str): 处理后的用户输入
             
         Returns:
-            str: 意图类型 ('quantity_follow_up', 'what_do_you_sell', 
-                         'recommendation', 'price_or_buy', 'unknown')
+            str: 意图类型 ('quantity_follow_up', 'what_do_you_sell',
+                         'recommendation', 'price_or_buy', 'policy_question', 'unknown')
         """
         # 检查是否是纯数量追问
         quantity_pattern = r'^\s*([\d一二三四五六七八九十百千万俩两]+)\s*(?:份|个|条|块|包|袋|盒|瓶|箱|打|磅|斤|公斤|kg|g|只|听|罐|组|件|本|支|枚|棵|株|朵|头|尾|条|片|串|扎|束|打|筒|碗|碟|盘|杯|壶|锅|桶|篮|筐|篓|扇|面|匹|卷|轴|封|枚|锭|丸|粒|钱|两|克|斗|石|顷|亩|分|厘|毫)?\s*(?:呢|呀|啊|吧|多少钱|总共)?\s*$'
@@ -154,6 +158,11 @@ class ChatHandler:
                for keyword in config.RECOMMEND_KEYWORDS):
             return 'recommendation'
             
+        # 检查是否是政策相关问题
+        for keywords in config.POLICY_KEYWORD_MAP.values():
+            if any(k in user_input_processed for k in keywords):
+                return 'policy_question'
+
         # 检查是否是价格查询或购买意图
         if (any(keyword in user_input_processed for keyword in config.PRICE_QUERY_KEYWORDS) or
             any(keyword in user_input_processed for keyword in config.BUY_INTENT_KEYWORDS)):
@@ -330,7 +339,21 @@ class ChatHandler:
         
         # 推荐后清除特定产品上下文
         self.update_user_session(user_id, product_key=None, product_details=None)
-        return "\n".join(response_parts) 
+        return "\n".join(response_parts)
+
+    def handle_policy_question(self, user_input_processed: str) -> Optional[str]:
+        """根据政策关键词返回公告中的相关语句。"""
+        if not self.policy_manager.lines:
+            return None
+
+        for section, keywords in config.POLICY_KEYWORD_MAP.items():
+            if any(k in user_input_processed for k in keywords):
+                excerpt = self.policy_manager.find_policy_excerpt(keywords)
+                if excerpt:
+                    return excerpt
+        # fallback simple search
+        excerpt = self.policy_manager.find_policy_excerpt([user_input_processed])
+        return excerpt if excerpt else None
 
     def _handle_price_or_buy_fallback_recommendation(self, user_input_original: str, user_input_processed: str, identified_query_product_name: Optional[str]) -> Optional[str]:
         """辅助函数：当handle_price_or_buy未找到精确产品时，生成相关的产品推荐。
@@ -719,6 +742,12 @@ class ChatHandler:
             final_response = self.handle_recommendation(user_input_processed, user_id)
             intent_handled = True
             new_context_key = None # Clear context for new recommendation
+
+        elif intent == 'policy_question':
+            final_response = self.handle_policy_question(user_input_processed)
+            if final_response:
+                intent_handled = True
+                new_context_key = None
 
         elif intent == 'price_or_buy':
             response, handled, ctx_key = self.handle_price_or_buy(user_input_processed, user_input_original, user_id)

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 # config.py
+import os
 
 # --- 模糊匹配配置 ---
 FUZZY_MATCH_THRESHOLD = 0.6
@@ -9,6 +10,16 @@ PRICE_QUERY_KEYWORDS = ["多少钱", "价格是", "什么价", "价钱"]
 WHAT_DO_YOU_SELL_KEYWORDS = ["卖什么", "有什么产品", "商品列表", "菜单", "有哪些东西", "有什么卖"]
 RECOMMEND_KEYWORDS = ["推荐", "介绍点", "什么好吃", "什么值得买", "有什么好", "当季", "新鲜"]
 FOLLOW_UP_KEYWORDS = ["它", "这个", "那个", "这", "那", "刚才", "刚刚"]
+
+# --- 平台政策关键词 ---
+POLICY_KEYWORD_MAP = {
+    "delivery": ["配送", "送货", "运费", "截单"],
+    "refund": ["退款", "退货", "质量", "credit"],
+    "payment": ["付款", "支付", "venmo", "汇款"],
+    "pickup": ["取货", "自取", "取货点", "地址"]
+}
+
+POLICY_FILE = os.getenv("POLICY_FILE", "policy.md")
 
 # --- 产品类别关键词 ---
 FRUIT_KEYWORDS = ["苹果", "梨", "香蕉", "橙子", "橘子", "柚子", "葡萄", "西瓜", "哈密瓜", "草莓", "蓝莓",
@@ -42,7 +53,6 @@ LLM_MODEL_NAME = "deepseek-chat" # 模型名称
 DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
 
 # --- 其他配置 ---
-import os
 
 # 允许通过环境变量自定义产品 CSV 路径，默认使用仓库根目录下的 products.csv
 PRODUCT_DATA_FILE = os.getenv("PRODUCT_DATA_FILE", "products.csv")

--- a/policy_manager.py
+++ b/policy_manager.py
@@ -1,0 +1,32 @@
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+class PolicyManager:
+    """Load and search policy text for quick lookup."""
+
+    def __init__(self, policy_file='policy.md'):
+        self.policy_file = policy_file
+        self.lines = []
+        self.load_policy()
+
+    def load_policy(self):
+        if not os.path.isabs(self.policy_file):
+            base_dir = os.path.dirname(os.path.abspath(__file__))
+            self.policy_file = os.path.join(base_dir, self.policy_file)
+        try:
+            with open(self.policy_file, 'r', encoding='utf-8') as f:
+                self.lines = [line.strip() for line in f if line.strip()]
+            logger.info(f"Policy loaded from {self.policy_file}, {len(self.lines)} lines")
+        except FileNotFoundError:
+            logger.warning(f"Policy file {self.policy_file} not found")
+            self.lines = []
+
+    def find_policy_excerpt(self, keywords):
+        """Return the first matching line using keywords priority."""
+        for kw in keywords:
+            for line in self.lines:
+                if kw in line:
+                    return line
+        return ''

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,25 @@
+import unittest
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from policy_manager import PolicyManager
+from chat_handler import ChatHandler
+from product_manager import ProductManager
+from cache_manager import CacheManager
+
+class TestPolicyQuestion(unittest.TestCase):
+    def setUp(self):
+        self.pm = ProductManager()
+        self.pm.load_product_data()
+        self.policy = PolicyManager()
+        self.handler = ChatHandler(product_manager=self.pm,
+                                   policy_manager=self.policy,
+                                   cache_manager=CacheManager())
+
+    def test_delivery_question(self):
+        response = self.handler.handle_chat_message('配送时间是什么时候', 'u1')
+        self.assertIn('星期三截单星期五送货', response)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce `PolicyManager` to load policy text
- detect policy questions in `ChatHandler`
- respond to policy questions using policy excerpts
- wire up `PolicyManager` in `app.py`
- ignore cache directory and add tests for policy questions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb74cc7e883268e0f905d6bf6bd4f