### PR TITLE
Implement dark mode theme toggle

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -1,0 +1,20 @@
+function applyTheme(mode) {
+    if (mode === 'dark') {
+        document.body.classList.add('dark-mode');
+    } else {
+        document.body.classList.remove('dark-mode');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    const savedTheme = localStorage.getItem('theme');
+    applyTheme(savedTheme);
+
+    const toggleBtn = document.getElementById('themeToggle');
+    if (toggleBtn) {
+        toggleBtn.addEventListener('click', function () {
+            const isDark = document.body.classList.toggle('dark-mode');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        });
+    }
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,39 @@
+:root {
+    --primary-color: #4CAF50;
+    --primary-dark: #3d8b40;
+    --primary-light: #c8e6c9;
+    --secondary-color: #FF9800;
+    --text-color: #333;
+    --light-bg: #f8f9fa;
+    --white: #ffffff;
+    --shadow: 0 4px 15px rgba(0,0,0,0.1);
+    --border-radius: 12px;
+}
+
+body.dark-mode {
+    --primary-color: #81C784;
+    --primary-dark: #66BB6A;
+    --primary-light: #2E7D32;
+    --secondary-color: #FFB74D;
+    --text-color: #f1f1f1;
+    --light-bg: #424242;
+    --white: #303030;
+    --shadow: 0 4px 15px rgba(0,0,0,0.4);
+
+    background: linear-gradient(135deg, #1e1e1e 0%, #2c2c2c 100%);
+}
+
+#themeToggle {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    color: var(--primary-color);
+    font-size: 1.2em;
+    cursor: pointer;
+}
+
+body.dark-mode #themeToggle {
+    color: var(--secondary-color);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,18 +6,8 @@
     <title>智能果蔬助手</title>
     <!-- 引入Font Awesome图标库 -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel='stylesheet' href='{{ url_for('static', filename='style.css') }}'>
     <style>
-        :root {
-            --primary-color: #4CAF50;
-            --primary-dark: #3d8b40;
-            --primary-light: #c8e6c9;
-            --secondary-color: #FF9800;
-            --text-color: #333;
-            --light-bg: #f8f9fa;
-            --white: #ffffff;
-            --shadow: 0 4px 15px rgba(0,0,0,0.1);
-            --border-radius: 12px;
-        }
 
         html {
             height: 100%;
@@ -360,6 +350,7 @@
             <i class="fas fa-leaf logo-icon"></i>
             <h1>智能果蔬助手</h1>
         </div>
+        <button id="themeToggle" aria-label="Toggle dark mode"><i class="fas fa-moon"></i></button>
     </header>
     
     <div id="chatContainer">
@@ -527,5 +518,6 @@
             return userId;
         }
     </script>
+    <script src='{{ url_for('static', filename='chat.js') }}'></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- define color variables and dark-mode overrides in new `static/style.css`
- add theme toggle button in `index.html`
- load `style.css` and `chat.js` from Flask static folder
- store theme preference in `localStorage`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbea6faa88326b08094b7c1931930